### PR TITLE
If we're not logging in using :login, just call super

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ActiveRecord::Base
       where(arel_table[:username].lower.eq(login.downcase).or(
             arel_table[:email].lower.eq(login.downcase))).first
     else
-      where(conditions).first
+      super
     end
   end
 


### PR DESCRIPTION
I've noticed a case whereby this method will fail (with an `ActiveModel::ForbiddenAttributesError` exception) when called with `warden_conditions` containing the key `unconfirmed_email`. This case occurs when the user is reconfirming an email address.

Rather than account for edge cases created by included devise modules, let devise work out what to do.
